### PR TITLE
Automated builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,43 @@
+name: Continuous Integration
+
+on:
+  push:
+    # Sequence of patterns matched against refs/tags
+    tags:
+      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+
+    - name: Add msbuild to PATH
+      uses: microsoft/setup-msbuild@v1.0.2
+
+    - name: Get version info
+      id: get_version
+      run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/v}
+      
+    - name: Build with msbuild
+      run: MSBuild.exe -t:restore,build,ILMerge -p:Configuration=Release -p:OutputPath=../TaskbarMonitor-win-x64/ -p:VersionAssembly=${{ steps.get_version.outputs.VERSION }}
+
+    - name: Create release
+      uses: softprops/action-gh-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ steps.tag_info.outputs.SOURCE_TAG }}
+        name: TaskbarMonitor ${{ steps.get_version.outputs.VERSION }}
+        draft: false
+        prerelease: false
+        body: ${{ github.event.head_commit.message }}
+        files: |
+          ./TaskbarMonitor-win-x64/*.*

--- a/TaskbarMonitor/TaskbarMonitor.csproj
+++ b/TaskbarMonitor/TaskbarMonitor.csproj
@@ -41,10 +41,17 @@
   <PropertyGroup>
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
+  <Target Name="ILMerge">
+    <!-- the ILMergePath property points to the location of ILMerge.exe console application -->
+    <Exec Command="$(ILMergeConsolePath) /out:$(OutDir)TaskbarMonitor-merged.dll $(OutDir)TaskbarMonitor.dll $(OutDir)Newtonsoft.Json.dll" />
+    <Exec Command="del /F /Q &quot;$(OutDir)TaskbarMonitor.dll&quot;" />
+    <Exec Command="del /F /Q &quot;$(OutDir)TaskbarMonitor.dll.config&quot;" />
+    <Exec Command="del /F /Q &quot;$(OutDir)TaskbarMonitor.pdb&quot;" />
+    <Exec Command="del /F /Q &quot;$(OutDir)Newtonsoft.Json.dll&quot;" />
+    <Exec Command="del /F /Q &quot;$(OutDir)TaskbarMonitor-merged.pdb&quot;" />
+    <Exec Command="ren &quot;$(OutDir)TaskbarMonitor-merged.dll&quot; &quot;$(OutDir)TaskbarMonitor.dll&quot;" />
+  </Target>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -107,7 +114,6 @@
     <None Include="App.config" />
     <None Include="app.manifest" />
     <None Include="leandro.pfx" />
-    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Controls\NewFolder1\" />
@@ -115,5 +121,14 @@
   <ItemGroup>
     <Content Include="icon.ico" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="ILMerge">
+      <Version>3.0.41</Version>
+    </PackageReference>
+    <PackageReference Include="Newtonsoft.Json">
+      <Version>12.0.3</Version>
+    </PackageReference>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\BuildCommon.targets" />
 </Project>

--- a/TaskbarMonitor/packages.config
+++ b/TaskbarMonitor/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net472" />
-</packages>

--- a/TaskbarMonitorInstaller/Program.cs
+++ b/TaskbarMonitorInstaller/Program.cs
@@ -25,8 +25,7 @@ namespace TaskbarMonitorInstaller
             InstallInfo info = new InstallInfo
             {
                 FilesToCopy = new Dictionary<string, byte[]> { 
-                    { "TaskbarMonitor.dll", Properties.Resources.TaskbarMonitor }, 
-                    { "Newtonsoft.Json.dll", Properties.Resources.Newtonsoft_Json } 
+                    { "TaskbarMonitor.dll", Properties.Resources.TaskbarMonitor }
                 },
                 FilesToRegister = new List<string> { "TaskbarMonitor.dll" },
                 //TargetPath = System.IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Programs", "TaskbarMonitor")

--- a/TaskbarMonitorInstaller/Properties/Resources.resx
+++ b/TaskbarMonitorInstaller/Properties/Resources.resx
@@ -118,12 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="Newtonsoft_Json" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\Newtonsoft.Json.dll;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="TaskbarMonitor" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\TaskbarMonitor.dll;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
   <data name="Version" xml:space="preserve">
     <value>0.3.4</value>
   </data>

--- a/TaskbarMonitorInstaller/TaskbarMonitorInstaller.csproj
+++ b/TaskbarMonitorInstaller/TaskbarMonitorInstaller.csproj
@@ -38,6 +38,17 @@
   <PropertyGroup>
     <ApplicationIcon>icon.ico</ApplicationIcon>
   </PropertyGroup>
+  <Target Name="ILMerge">
+    <!-- the ILMergePath property points to the location of ILMerge.exe console application -->
+    <Exec Command="$(ILMergeConsolePath) /out:$(OutDir)TaskbarMonitorInstaller-merged.exe $(OutDir)TaskbarMonitorInstaller.exe $(OutDir)TaskbarMonitor.dll" />
+    <Exec Command="del /F /Q &quot;$(OutDir)TaskbarMonitor.dll&quot;" />
+    <Exec Command="del /F /Q &quot;$(OutDir)TaskbarMonitorInstaller.pdb&quot;" />
+    <Exec Command="del /F /Q &quot;$(OutDir)TaskbarMonitorInstaller-merged.pdb&quot;" />
+    <Exec Command="del /F /Q &quot;$(OutDir)TaskbarMonitorInstaller.exe.config&quot;" />
+    <Exec Command="del /F /Q &quot;$(OutDir)TaskbarMonitorInstaller.exe.config&quot;" />
+    <Exec Command="del /F /Q &quot;$(OutDir)TaskbarMonitorInstaller.exe&quot;" />
+    <Exec Command="ren &quot;$(OutDir)TaskbarMonitorInstaller-merged.exe&quot; &quot;$(OutDir)TaskbarMonitorInstaller.exe&quot;" />
+  </Target>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -53,22 +64,11 @@
     <Compile Include="BLL\Win32Api.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Properties\Resources.Designer.cs">
-      <AutoGen>True</AutoGen>
-      <DesignTime>True</DesignTime>
-      <DependentUpon>Resources.resx</DependentUpon>
-    </Compile>
+    <Compile Include="Properties\Resources.Designer.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
     <None Include="app.manifest" />
-  </ItemGroup>
-  <ItemGroup>
-    <EmbeddedResource Include="Properties\Resources.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
-      <SubType>Designer</SubType>
-    </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
     <None Include="Resources\Newtonsoft.Json.dll" />
@@ -79,5 +79,16 @@
   <ItemGroup>
     <Content Include="icon.ico" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="ILMerge">
+      <Version>3.0.41</Version>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Properties\Resources.resx">
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\BuildCommon.targets" />
 </Project>


### PR DESCRIPTION
- Migrate packages.config to PackageReference
- Add BuildCommon.targets for make AssemblyVersion change possible

Needed to change some things in the Resources part, because now all is merged automatically into a single file.

There is still a problem though, because I and GitHub do not have the "leandro.pfx"file. I have no idea if that can be fixed somehow.. Would be a pity if that is a showstopper for automated builds.