### PR TITLE
add null check for screen

### DIFF
--- a/TaskbarMonitor/TaskbarManager.cs
+++ b/TaskbarMonitor/TaskbarManager.cs
@@ -178,16 +178,17 @@ namespace TaskbarMonitor
 
         private MonitorOptions GetOptionsForTaskbar(Taskbar tb)
         {
-            MonitorOptions mopt = null;            
+            MonitorOptions mopt = null;
             var pos = BLL.Win32Api.GetWindowSize(tb.TargetWnd);
             foreach (var item in this.Monitor.Options.MonitorOptions)
             {
-                if (pos.IntersectsWith(Screen.AllScreens.Where(x => x.DeviceName == item.Key).Single().Bounds))                
-                {                    
+                var screen = Screen.AllScreens.SingleOrDefault(x => x.DeviceName == item.Key);
+                if (screen != null && pos.IntersectsWith(screen.Bounds))
+                {
                     mopt = item.Value;
                 }
             }
-            return mopt;            
+            return mopt;
         }
 
         private bool AddControlToTaskbar(WindowInformation taskbarArea, WindowInformation trayArea, bool isMainTaskbar)


### PR DESCRIPTION
1. The Issue:  
I am using multiple monitors and machine with KVM on windows11, when switching monitor the application exited.

2. The fix
Debug and find the cause.
Just a simple fix: add null check for screen.