### PR TITLE
Added 5px padding to the taskbar watcher

### DIFF
--- a/TaskbarMonitor/SystemWatcherControl.cs
+++ b/TaskbarMonitor/SystemWatcherControl.cs
@@ -312,6 +312,7 @@ namespace TaskbarMonitor
             int counterSize = (Options.HistorySize + 10);
             int controlWidth = counterSize * CountersCount;
             int controlHeight = minimumHeight;
+            int padding = 5;
 
             if (VerticalTaskbarMode && taskbarWidth < controlWidth)
             {
@@ -321,13 +322,13 @@ namespace TaskbarMonitor
             }
             if (VerticalTaskbarMode)
             {
-                this.Left = 5;
-                controlWidth = controlWidth - 5;
+                this.Left = padding;
+                controlWidth = controlWidth - padding;
             }
             else 
             { 
-                this.Top = 1;
-                controlHeight = controlHeight - 2;
+                this.Top = padding;
+                controlHeight = controlHeight - padding - 2;
             }
             if (this.Size.Width != controlWidth || this.Size.Height != controlHeight)
             {


### PR DESCRIPTION
When the taskbar behavior is auto-hide, the top pixels of the graphs are visible at the bottom of the screen when the taskbar isn't showing. The 5px padding prevents that.